### PR TITLE
Add CSV import script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 dist
 .env
 .DS_Storenode_modules
-scripts/import-csv.js
 APIOps Cycles - Lines.csv
 APIOps Cycles - Methods.csv
 APIOps Cycles - Resources.csv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # www
 APIOps Cycles Method website
+
+## Import content from CSV
+
+Place `APIOps Cycles - Methods.csv`, `APIOps Cycles - Lines.csv` and
+`APIOps Cycles - Resources.csv` in the project root. Then run:
+
+```bash
+npm run import:csv
+```
+
+This command parses the CSV files with `papaparse` and generates Markdown
+files under `src/content`.

--- a/scripts/import-csv.js
+++ b/scripts/import-csv.js
@@ -1,0 +1,48 @@
+import fs from 'fs/promises';
+import path from 'path';
+import Papa from 'papaparse';
+import matter from 'gray-matter';
+
+function slugify(str = '') {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+async function importCsv(csvFile, outDir) {
+  let csv;
+  try {
+    csv = await fs.readFile(csvFile, 'utf8');
+  } catch (err) {
+    console.error(`Could not read ${csvFile}: ${err.message}`);
+    return;
+  }
+  const result = Papa.parse(csv, { header: true, skipEmptyLines: true });
+  await fs.mkdir(path.join('src', 'content', outDir), { recursive: true });
+
+  for (const row of result.data) {
+    const body = row.body || row.content || row.Content || '';
+    const slug = row.slug || row.Slug || slugify(row.title || row.Title || '');
+    const data = { ...row, slug };
+    delete data.body;
+    delete data.content;
+    delete data.Content;
+
+    const markdown = matter.stringify(body, data);
+    const filePath = path.join('src', 'content', outDir, `${slug}.md`);
+    await fs.writeFile(filePath, markdown, 'utf8');
+    console.log(`Wrote ${filePath}`);
+  }
+}
+
+async function main() {
+  await importCsv('APIOps Cycles - Methods.csv', 'methods');
+  await importCsv('APIOps Cycles - Lines.csv', 'lines');
+  await importCsv('APIOps Cycles - Resources.csv', 'resources');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to import Markdown from CSV files using papaparse
- document how to generate the Markdown files
- remove script entry from .gitignore

## Testing
- `node scripts/import-csv.js` *(fails: Cannot find package 'papaparse')*

------
https://chatgpt.com/codex/tasks/task_b_686e794cc4c0832cad114cda098a81e8