### PR TITLE
Configure Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This command parses the CSV files with `papaparse` and generates Markdownfiles u
 Deploy the site on Netlify using the included adapter:
 
 1. Install dependencies with `npm install`.
-2. Build the site using `npm run build`.
+2. Build the site using `npm run build`. This compiles Tailwind using
+   `tailwind.config.cjs` and outputs the final `dist` folder.
 3. Push the repository to a connected Netlify project.
 
 Netlify reads `netlify.toml` to run the build command and serve the

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import '../styles/global.css';
 const { title } = Astro.props;
 ---
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .btn {
+    @apply inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700;
+  }
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,4 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  presets: [require('@astrojs/tailwind/preset')],
+};


### PR DESCRIPTION
## Summary
- add `tailwind.config.cjs` with Astro preset
- add `src/styles/global.css`
- import global styles in `Layout.astro`
- document Tailwind build step in README

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e882b77b8832c832fa3e973633093