### PR TITLE
Fix frontmatter destructuring for Astro pages

### DIFF
--- a/src/pages/lines/[slug].astro
+++ b/src/pages/lines/[slug].astro
@@ -13,7 +13,8 @@ export async function getStaticPaths() {
 const { slug } = Astro.props;
 const entry = await getEntryBySlug('lines', slug);
 if (!entry) throw new Error(`No entry found for slug: ${slug}`);
-const { Content, frontmatter } = await entry.render();
+const { Content } = await entry.render();
+const frontmatter = entry.data;
 ---
 
 <Layout title={frontmatter.title}>

--- a/src/pages/methods/[slug].astro
+++ b/src/pages/methods/[slug].astro
@@ -20,7 +20,8 @@ if (!entry) {
   throw new Error(`No entry found for slug: ${slug}`);
 }
 
-const { Content, frontmatter } = await entry.render();
+const { Content } = await entry.render();
+const frontmatter = entry.data;
 
 const {
   title,

--- a/src/pages/resources/[slug].astro
+++ b/src/pages/resources/[slug].astro
@@ -13,7 +13,8 @@ export async function getStaticPaths() {
 const { slug } = Astro.props;
 const entry = await getEntryBySlug('resources', slug);
 if (!entry) throw new Error(`No entry found for slug: ${slug}`);
-const { Content, frontmatter } = await entry.render();
+const { Content } = await entry.render();
+const frontmatter = entry.data;
 ---
 
 <Layout title={frontmatter.title}>


### PR DESCRIPTION
## Summary
- adapt to astro content API: use `entry.data` for frontmatter

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ed70c7940832c9a8888f6908359b9